### PR TITLE
Force to mainviewport

### DIFF
--- a/WhereIsMyMouse/PluginUI.cs
+++ b/WhereIsMyMouse/PluginUI.cs
@@ -2,6 +2,7 @@
 using System;
 using System.Drawing;
 using System.Numerics;
+using Dalamud.Interface;
 using Dalamud.Logging;
 
 namespace WhereIsMyMouse
@@ -77,6 +78,7 @@ namespace WhereIsMyMouse
                 return;
             }
 
+            ImGuiHelpers.ForceNextWindowMainViewport();
             ImGui.SetNextWindowSize(new Vector2(375, 330), ImGuiCond.FirstUseEver);
             ImGui.SetNextWindowSizeConstraints(new Vector2(375, 330), new Vector2(float.MaxValue, float.MaxValue));
             if (ImGui.Begin("Cursor Settings", ref this.visible, ImGuiWindowFlags.NoScrollbar | ImGuiWindowFlags.NoScrollWithMouse))


### PR DESCRIPTION
This forces the created window to the main viewport even when the user has Multi-Monitor Support enabled.
Imgui windows do not support transparency when they exist outside the main viewport for any reason, this change ensures that the drawn window will not go fully opaque