### PR TITLE
adding NoFocusOnAppearing to plugin window

### DIFF
--- a/WhereIsMyMouse/PluginUI.cs
+++ b/WhereIsMyMouse/PluginUI.cs
@@ -107,7 +107,7 @@ namespace WhereIsMyMouse
             Vector2 cursorPos = ImGui.GetMousePos();
             ImGui.SetNextWindowSize(new Vector2(300, 300));
             ImGuiHelpers.ForceNextWindowMainViewport();
-            ImGui.Begin("CursorWindow", ImGuiWindowFlags.NoBackground | ImGuiWindowFlags.NoDecoration | ImGuiWindowFlags.NoInputs);
+            ImGui.Begin("CursorWindow", ImGuiWindowFlags.NoBackground | ImGuiWindowFlags.NoDecoration | ImGuiWindowFlags.NoInputs | ImGuiWindowFlags.NoFocusOnAppearing);
             ImGui.SetWindowPos(cursorPos - new Vector2(150,150));
             
             ImDrawListPtr draw;


### PR DESCRIPTION
Currently the plugin steals focus from other windows when it appears. This is particularly apparent when they are set to appear when entering combat. In this case they would steal focus from other plugin windows like chat plugins.